### PR TITLE
scroll clicked element to center, not top

### DIFF
--- a/src/components/ResultItem.js
+++ b/src/components/ResultItem.js
@@ -72,7 +72,7 @@ class ResultItem extends Component {
 
     componentDidUpdate(prevProps) {
         if (this.props.url === this.props.doc.url && 'scrollIntoView' in this.node) {
-            this.node.scrollIntoView({ behavior: 'smooth' });
+            this.node.scrollIntoView({ behavior: 'smooth', block: 'center' });
         }
     }
 


### PR DESCRIPTION
Reported by @salevajo – I think this should be a good enough fix.