### PR TITLE
Pagination fixes

### DIFF
--- a/src/build-search-query.js
+++ b/src/build-search-query.js
@@ -38,10 +38,10 @@ function buildSortQuery(order) {
 
     switch (order) {
         case SORT_NEWEST:
-            sort = [{ date: { order: 'desc' } }, ...sort];
+            sort = [{ date: { order: 'desc', missing: '_last' } }, ...sort];
             break;
         case SORT_OLDEST:
-            sort = [{ date: { order: 'asc' } }, ...sort];
+            sort = [{ date: { order: 'asc', missing: '_last' } }, ...sort];
             break;
     }
 

--- a/src/components/Filters.js
+++ b/src/components/Filters.js
@@ -27,7 +27,9 @@ class Filters extends Component {
     };
 
     filter = key => value =>
-        this.props.dispatch(updateSearchQuery({ [key]: value }));
+        this.props.dispatch(
+            updateSearchQuery({ [key]: value }, { resetPagination: true })
+        );
 
     loadMore = key => () => this.props.dispatch(expandFacet(key));
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,3 +7,5 @@ export const SEARCH_GUIDE =
 export const SIZE_OPTIONS = [10, 50, 200, 1000];
 export const DATE_FORMAT = 'yyyy-MM-dd';
 export const DEFAULT_FACET_SIZE = 10;
+export const ES_LONG_MAX = '9223372036854775807';
+export const ES_LONG_MIN = '-9223372036854775808';


### PR DESCRIPTION
I have not been able to reproduce the exact issue that was reported, but I found a few bugs in pagination that I've fixed:

1. Pagination must be reset (i.e. moved to page = 1) when a filter is changed.
2. Since the `date` field on docs is optional, pagination could get into a weird state when date sorting was selected.

It is possible that #2 caused the problem @germakoci described.