### PR TITLE
Use a normal link for the title

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -66,10 +66,9 @@ class Header extends Component {
                             variant="h6"
                             color="inherit"
                             className={classes.flex}>
-                            <Link href="/">
-                                <a className={classes.noLink + ' the-title'}
-                                    dangerouslySetInnerHTML={{__html: whoami.title}} />
-                            </Link>
+                            <a href="/"
+                                className={classes.noLink + ' the-title'}
+                                dangerouslySetInnerHTML={{__html: whoami.title}} />
                         </Typography>
                         <Menu whoami={whoami} />
                     </Toolbar>


### PR DESCRIPTION
Otherwise, when clicking on the inner link, that comes from `whoami.title`, the href doesn't count, because the click event is intercepted by the `<Link>` thing.